### PR TITLE
Added new command 'wait-terminal-status'

### DIFF
--- a/src/CIQS-CLI-Extension/azext_ciqs/__init__.py
+++ b/src/CIQS-CLI-Extension/azext_ciqs/__init__.py
@@ -31,6 +31,7 @@ class CiqsCommandsLoader(AzCommandsLoader):
             g.custom_command('view-provisioning-step', 'viewCurrentProvisioningStep', table_transformer=format.transform_provisioningStep)
             g.custom_command('view-status', 'viewDeploymentStatus', table_transformer=format.transform_deploymentViewStatus)
             g.custom_command('view-params', 'getDeploymentParameters', table_transformer=format.transform_deploymentViewParamsList)
+            g.custom_command('wait-terminal-status', 'waitForTerminalStatus')
 
         with self.command_group('ciqs template') as g:
             g.custom_command('list', 'listTemplates', table_transformer=format.transform_templateList)
@@ -58,5 +59,7 @@ class CiqsCommandsLoader(AzCommandsLoader):
             c.argument('location', options_list=('--location', '-l'), help='Location to deploy. See "az ciqs template locations -h"')
             c.argument('description', options_list=('--description',), help='Describe the deployment.')
 
+        with self.argument_context('ciqs deployment wait-terminal-status') as c:
+            c.argument('timeout', options_list=('--timeout',), help='Max time to wait for terminal status')
 
 COMMAND_LOADER_CLS = CiqsCommandsLoader

--- a/src/CIQS-CLI-Extension/azext_ciqs/api.py
+++ b/src/CIQS-CLI-Extension/azext_ciqs/api.py
@@ -42,11 +42,11 @@ def makeAPICall(method, path, auth_token=None, refresh_token=False, requestBody=
     # Use the environment variable to run api calls against the test api instead of production api.
     if os.getenv(TEST_ENVIRONMENT_VAR, False) == "Remote":
         host = TEST_HOST_REMOTE
-        logger.warning('Using test api...')
+        #logger.warning('Using test api...')
     elif os.getenv(TEST_ENVIRONMENT_VAR, False) == "Local":
         host = TEST_HOST_LOCAL
         port = TEST_PORT_LOCAL
-        logger.warning('Running local api...')
+        #logger.warning('Running local api...')
     # Build the appropriate headers:
     headers = {'Accept': 'application/json'}
     # Check to see if specific headers should be added.

--- a/src/CIQS-CLI-Extension/azext_ciqs/helps.py
+++ b/src/CIQS-CLI-Extension/azext_ciqs/helps.py
@@ -65,6 +65,11 @@ helps['ciqs deployment view-status'] = """
     short-summary: View the current status of the deployment.
 """
 
+helps['ciqs deployment wait-terminal-status'] = """
+    type: command
+    short-summary: Waits for a terminal status to be reached and then return the status.
+"""
+
 # --------------------------------------------------------------------------------------------
 # gallery
 # --------------------------------------------------------------------------------------------

--- a/src/CIQS-CLI-Extension/azext_ciqs/util.py
+++ b/src/CIQS-CLI-Extension/azext_ciqs/util.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from collections import defaultdict
+from collections import Set
 
 STATUS_DICT = defaultdict(lambda: 'Unknown',
                          {'created': 'Created',
@@ -22,3 +23,5 @@ def provisioningStatusTransform(status):
     """Transforms provisioning status into a human readable form"""
     status = status.lower()
     return STATUS_DICT[status]
+
+TERMINAL_STATUSES = set(['timeout', 'actionRequired', 'failed', 'ready', 'deleted'])


### PR DESCRIPTION
Added wait-terminal-status for easier scripting and testing.
When ran, it will wait until the status of the deployment is terminal (not provisioning).
Once complete, it will return the status.
It is useful when waiting for action required or ready status.
